### PR TITLE
Add hot-reload script

### DIFF
--- a/src/js/background/hot-reload.js
+++ b/src/js/background/hot-reload.js
@@ -1,43 +1,51 @@
 // From https://github.com/xpl/crx-hotreload
 
-const filesInDirectory = dir => new Promise(resolve =>
-    dir.createReader().readEntries(entries =>
-        Promise.all(entries.filter(e => e.name[0] !== '.').map(e =>
-            e.isDirectory
-                ? filesInDirectory(e)
-                : new Promise(resolve => e.file(resolve))
-        ))
-            .then(files => [].concat(...files))
-            .then(resolve)
-    )
-)
+const filesInDirectory = (dir) => {
+	return new Promise((resolve) => {
+		return dir
+			.createReader()
+			.readEntries((entries) => {
+				const filePromises = entries
+					.filter(e => e.name[0] !== '.')
+					.map(e => e.isDirectory ? filesInDirectory(e) : new Promise(resolve => e.file(resolve)));
 
-const timestampForFilesInDirectory = dir =>
-    filesInDirectory(dir).then(files =>
-        files.map(f => f.name + f.lastModifiedDate).join())
+				return Promise.all(filePromises)
+					.then(files => [].concat(...files))
+					.then(resolve);
+			});
+	});
+};
+
+const timestampForFilesInDirectory = (dir) => {
+	return filesInDirectory(dir).then((files) => {
+		return files.map(f => f.name + f.lastModifiedDate).join();
+	});
+};
 
 const reload = () => {
-    // Currently, this refreshes only the currently active tab in Chrome
-    // But it would be possible to refresh all of the tabs that match the desired host (e.g. public or hosted github)
-    chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
-        if (tabs[0]) { chrome.tabs.reload(tabs[0].id) }
-        chrome.runtime.reload()
-    })
+	// Currently, this refreshes only the currently active tab in Chrome
+	// But it would be possible to refresh all of the tabs that match the desired host (e.g. public or hosted github)
+	chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+		if (tabs[0]) {
+			chrome.tabs.reload(tabs[0].id);
+		}
+		chrome.runtime.reload();
+	});
 }
 
 const watchChanges = (dir, lastTimestamp) => {
-    timestampForFilesInDirectory(dir).then(timestamp => {
-        if (!lastTimestamp || (lastTimestamp === timestamp)) {
-            setTimeout(() => watchChanges(dir, timestamp), 1000) // retry after 1s
-        } else {
-            reload()
-        }
-    })
+	timestampForFilesInDirectory(dir).then((timestamp) => {
+		if (!lastTimestamp || (lastTimestamp === timestamp)) {
+			setTimeout(() => watchChanges(dir, timestamp), 1000); // retry after 1s
+		} else {
+			reload();
+		}
+	});
 
 }
 
-chrome.management.getSelf(self => {
-    if (self.installType === 'development') {
-        chrome.runtime.getPackageDirectoryEntry(dir => watchChanges(dir))
-    }
-})
+chrome.management.getSelf((self) => {
+	if (self.installType === 'development') {
+		chrome.runtime.getPackageDirectoryEntry(dir => watchChanges(dir));
+	}
+});

--- a/src/js/background/hot-reload.js
+++ b/src/js/background/hot-reload.js
@@ -1,0 +1,43 @@
+// From https://github.com/xpl/crx-hotreload
+
+const filesInDirectory = dir => new Promise(resolve =>
+    dir.createReader().readEntries(entries =>
+        Promise.all(entries.filter(e => e.name[0] !== '.').map(e =>
+            e.isDirectory
+                ? filesInDirectory(e)
+                : new Promise(resolve => e.file(resolve))
+        ))
+            .then(files => [].concat(...files))
+            .then(resolve)
+    )
+)
+
+const timestampForFilesInDirectory = dir =>
+    filesInDirectory(dir).then(files =>
+        files.map(f => f.name + f.lastModifiedDate).join())
+
+const reload = () => {
+    // Currently, this refreshes only the currently active tab in Chrome
+    // But it would be possible to refresh all of the tabs that match the desired host (e.g. public or hosted github)
+    chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+        if (tabs[0]) { chrome.tabs.reload(tabs[0].id) }
+        chrome.runtime.reload()
+    })
+}
+
+const watchChanges = (dir, lastTimestamp) => {
+    timestampForFilesInDirectory(dir).then(timestamp => {
+        if (!lastTimestamp || (lastTimestamp === timestamp)) {
+            setTimeout(() => watchChanges(dir, timestamp), 1000) // retry after 1s
+        } else {
+            reload()
+        }
+    })
+
+}
+
+chrome.management.getSelf(self => {
+    if (self.installType === 'development') {
+        chrome.runtime.getPackageDirectoryEntry(dir => watchChanges(dir))
+    }
+})

--- a/src/js/background/index.js
+++ b/src/js/background/index.js
@@ -1,4 +1,5 @@
 import { defaultExtensionOptions } from "../../common/options";
+import "./hot-reload";
 
 let settings;
 const maxTries = 2;


### PR DESCRIPTION
From https://github.com/xpl/crx-hotreload
Automatically disabled when install type is not development

It works okay. I've found that it works most of the time, but requires a manual refresh under some circumstances. Better than having to hit reload on the Extensions page every time.